### PR TITLE
Update package.json type

### DIFF
--- a/index.js
+++ b/index.js
@@ -414,4 +414,4 @@ var vueTouchEvents = {
  * Exports
  */
 
-module.exports = { vueTouchEvents }
+export default { vueTouchEvents }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "vue3-touch-events",
-  "version": "3.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "vue3-touch-events",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Simple touch events support for vue.js 3",
+  "type": "module",
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {


### PR DESCRIPTION
Hello. Thanks for the nice library!

Without `{"type": "module"}`, I see this error in VitePress:

```
(node:16307) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.
(Use `node --trace-warnings ...` to show where the warning was created)
build error:
 /home/user/project/node_modules/vue3-touch-events/index.js:416
export default vueTouchEvents
^^^^^^

SyntaxError: Unexpected token 'export'
    at Object.compileFunction (node:vm:360:18)
    at wrapSafe (node:internal/modules/cjs/loader:1048:15)
    at Module._compile (node:internal/modules/cjs/loader:1083:27)
    at Module._extensions..js (node:internal/modules/cjs/loader:1173:10)
    at Module.load (node:internal/modules/cjs/loader:997:32)
    at Module._load (node:internal/modules/cjs/loader:838:12)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/translators:170:29)
    at ModuleJob.run (node:internal/modules/esm/module_job:193:25)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:527:24)
 ELIFECYCLE  Command failed with exit code 1.
```

With `{"type": "module"}`, the component using `vue3-touch-events` works normally.

**UPD**: it got more confusing and I had to replace the import as well: `import vueTouchEvents from "vue3-touch-events";`

~Hopefully, it is OK to merge.~ Let's discuss how to integrate ESM, if possible.