### PR TITLE
🏷️ Fix types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
-import {PluginObject} from "vue";
+import {Plugin} from "vue";
 
-declare const Vue3TouchEvents: PluginObject<Vue3TouchEventsOptions>;
+declare const Vue3TouchEvents: Plugin<Vue3TouchEventsOptions>;
 
 export interface Vue3TouchEventsOptions {
   disableClick?: boolean;


### PR DESCRIPTION
Fixes https://github.com/robinrodricks/vue3-touch-events/issues/2

In Vue 3, the plugin type is now called [`Plugin`][1].

[1]: https://github.com/vuejs/core/blob/3127c4113e6ff381cd8f79a445655f759e08372a/packages/runtime-core/src/apiCreateApp.ts#L162