### PR TITLE
Clear timer on unmount

### DIFF
--- a/index.js
+++ b/index.js
@@ -376,6 +376,8 @@ var vueTouchEvents = {
             },
 
             unmounted: function ($el) {
+                cancelTouchHoldTimer($el.$$touchObj)
+
                 $el.removeEventListener('touchstart', touchStartEvent);
                 $el.removeEventListener('touchmove', touchMoveEvent);
                 $el.removeEventListener('touchcancel', touchCancelEvent);


### PR DESCRIPTION
If you delete an element before the "hold" event, you can get the error Uncaught TypeError: Cannot read properties of undefined (reading 'callbacks')

![image](https://github.com/robinrodricks/vue3-touch-events/assets/40947745/bab85bb1-5cca-45f0-81b9-10bdbfa582e5)
