### PR TITLE
🐛 Fix `cancelTouchHoldTimer()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -294,7 +294,7 @@ var vueTouchEvents = {
         }
 
         function cancelTouchHoldTimer($this) {
-            if ($this.touchHoldTimer) {
+            if ($this && $this.touchHoldTimer) {
                 clearTimeout($this.touchHoldTimer);
                 $this.touchHoldTimer = null;
             }


### PR DESCRIPTION
A [recent change][1] calls `cancelTouchHoldTimer()` in the `unmounted` hook.

However, sometimes `$el.$$touchObj` can be undefined (as seen in the [existing check][2]).

This then leads to an error when calling `cancelTouchHoldTimer()`, because it tries to access `touchHoldTimer` on `undefined`.

This change adds a check in `cancelTouchHoldTimer()` for this case.

[1]: https://github.com/robinrodricks/vue3-touch-events/pull/34
[2]: https://github.com/robinrodricks/vue3-touch-events/blob/15a08a29b89185eea1cda4be054f612abe4377cc/index.js#L386