### PR TITLE
Remove explicit type of plugin to make it work with vue 3.4.0

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 import {Plugin} from "vue";
 
-declare const Vue3TouchEvents: Plugin<Vue3TouchEventsOptions & undefined>;
+declare const Vue3TouchEvents: Plugin;
 
 export interface Vue3TouchEventsOptions {
   disableClick?: boolean;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,14 @@
 {
   "name": "vue3-touch-events",
-  "version": "3.1.0",
-  "lockfileVersion": 1
+  "version": "4.1.8",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vue3-touch-events",
+      "version": "4.1.8",
+      "license": "MIT",
+      "devDependencies": {}
+    }
+  }
 }


### PR DESCRIPTION
This removes the TypeScript errors that are thrown since Vue 3.4.0
I changed the type definition to be the same as in other Plugins (eg. https://github.com/Maronato/vue-toastification), not sure if this is the correct way to deal with this or it will even introduce problems with some functionalities.
For this I have to little knowledge how Vue plugins work exactly, but it fixed my problem and everything seems to work for my application.